### PR TITLE
fix "[Errno 111] Connection refused" after fail to run p0f for first time

### DIFF
--- a/src/sploitego/cmdtools/p0f.py
+++ b/src/sploitego/cmdtools/p0f.py
@@ -111,6 +111,7 @@ def fingerprint(ip):
             "!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!",
         )
         if p.returncode:
+            os.remove(us)
             raise P0fError('Could not locate or successfully execute the p0f executable.')
         return {'status': P0fStatus.NoMatch}
 


### PR DESCRIPTION
removes the temp socket file so 'if not os.path.exists(us)' will not be skipped on any other run after the first one.
